### PR TITLE
Uichkout 46

### DIFF
--- a/UserSearch/UserSearchModal.js
+++ b/UserSearch/UserSearchModal.js
@@ -13,6 +13,7 @@ export default class UserSearchModal extends React.Component {
     }).isRequired,
     selectUser: PropTypes.func.isRequired,
     closeCB: PropTypes.func.isRequired,
+    onCloseModal: PropTypes.func,
     openWhen: PropTypes.bool,
     dataKey: PropTypes.string,
   }

--- a/UserSearch/UserSearchModal.js
+++ b/UserSearch/UserSearchModal.js
@@ -55,7 +55,7 @@ export default class UserSearchModal extends React.Component {
       <Modal onClose={this.closeModal} size="large" open={this.props.openWhen} label="Select User" dismissible>
         <div className={css.userSearchModal}>
           {this.state.error ? <div className={css.userError}>{this.state.error}</div> : null}
-          <this.connectedApp {...this.props} onSelectRow={this.passUserOut} />
+          <this.connectedApp {...this.props} onSelectRow={this.passUserOut} onComponentWillUnmount={this.props.onCloseModal} />
         </div>
       </Modal>
     );


### PR DESCRIPTION
Resolves UICHKOUT-46:

This passes onCloseModal forward to the User props as onComponentWillUnmount. This depends on other PRs: [ui-checkout](https://github.com/folio-org/ui-checkout/pull/55), [ui-users](ui-users), [stripes-smart-components](https://github.com/folio-org/stripes-smart-components/pull/80)