### PR TITLE
Turn SearchAndSort's show-single-result off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add `dataKey` to connected Users component. Fixes UIPFU-4.
 * Use more-current stripes-components. Refs STRIPES-495.
 * Use more-current stripes-connect. Refs STRIPES-501.
+* Turn SearchAndSort's show-single-result feature off. Refs STSMACOM-52. Fixes UIREQ-60, UICHKOUT-54, UIU-373.
 
 ## [1.1.0](https://github.com/folio-org/ui-plugin-find-user/tree/v1.1.0) (2017-09-06)
 

--- a/UserSearch/UserSearchModal.js
+++ b/UserSearch/UserSearchModal.js
@@ -56,7 +56,7 @@ export default class UserSearchModal extends React.Component {
       <Modal onClose={this.closeModal} size="large" open={this.props.openWhen} label="Select User" dismissible>
         <div className={css.userSearchModal}>
           {this.state.error ? <div className={css.userError}>{this.state.error}</div> : null}
-          <this.connectedApp {...this.props} onSelectRow={this.passUserOut} onComponentWillUnmount={this.props.onCloseModal} />
+          <this.connectedApp {...this.props} onSelectRow={this.passUserOut} onComponentWillUnmount={this.props.onCloseModal} showSingleResult={false} />
         </div>
       </Modal>
     );


### PR DESCRIPTION
Restore the behavior of this plugin previous to [UIIN-58](https://issues.folio.org/browse/UIIN-58). This means a user-search that results in a single row will simply show that row, as before, rather than redirecting the browser to the user-details page for that row.

Refs [STSMACOM-52](https://issues.folio.org/browse/STSMACOM-52). Fixes [UIREQ-60](https://issues.folio.org/browse/UIREQ-60), [UICHKOUT-54](https://issues.folio.org/browse/UICHKOUT-54), [UIU-373](https://issues.folio.org/browse/UIU-373).