### PR TITLE
allow PropTypes.node for labels

### DIFF
--- a/UserSearch/UserSearch.js
+++ b/UserSearch/UserSearch.js
@@ -67,7 +67,7 @@ UserSearch.defaultProps = {
 };
 
 UserSearch.propTypes = {
-  searchLabel: PropTypes.string,
+  searchLabel: PropTypes.node,
   searchButtonStyle: PropTypes.string,
   marginBottom0: PropTypes.bool,
   marginTop0: PropTypes.bool,


### PR DESCRIPTION
Allow `PropTypes.node` instead of the more restrictive
`PropTypes.string` for labels that may be passed as `<FormattedMessage>`
objects.