### PR TITLE
accept id attribute for find-user button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-plugin-find-user
 
+## 1.6.0 (IN PROGRESS)
+
+* Accept an `id` prop for the find user button. Refs UIU-884.
+
 ## [1.5.0](https://github.com/folio-org/ui-plugin-find-user/tree/v1.5.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v1.4.0...v1.5.0)
 

--- a/UserSearch/UserSearch.js
+++ b/UserSearch/UserSearch.js
@@ -43,7 +43,7 @@ export default class UserSearch extends React.Component {
     return (
       <div className={this.getStyle()}>
         <Button
-          id="clickable-plugin-find-user"
+          id={this.props.id}
           key="searchButton"
           buttonStyle={this.props.searchButtonStyle}
           onClick={this.openModal}
@@ -63,10 +63,12 @@ export default class UserSearch extends React.Component {
 }
 
 UserSearch.defaultProps = {
+  id: 'clickable-plugin-find-user',
   searchButtonStyle: 'primary noRightRadius',
 };
 
 UserSearch.propTypes = {
+  id: PropTypes.string,
   searchLabel: PropTypes.node,
   searchButtonStyle: PropTypes.string,
   marginBottom0: PropTypes.bool,


### PR DESCRIPTION
Accept a prop for the element id of the find-user button. This allows
pages that may have multiple instances of the plugin to make sure each
find-user button has a unique ID.

Refs [UIU-884](https://issues.folio.org/browse/UIU-884)