### PR TITLE
Pass correct packageInfo into Users. Part of ERM-72.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.6.0 (IN PROGRESS)
 
 * Accept an `id` prop for the find user button. Refs UIU-884.
+* Pass correct `packageInfo` into Users. Refs of ERM-72.
 
 ## [1.5.0](https://github.com/folio-org/ui-plugin-find-user/tree/v1.5.0) (2019-01-25)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v1.4.0...v1.5.0)

--- a/UserSearch/UserSearchModal.js
+++ b/UserSearch/UserSearchModal.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Users from '@folio/users/src/Users';
 import { Modal } from '@folio/stripes/components';
+import packageInfo from '../package';
 
 import css from './UserSearch.css';
 
@@ -54,7 +55,7 @@ export default class UserSearchModal extends React.Component {
     return (
       <Modal enforceFocus={false} onClose={this.closeModal} contentClass={css.modalContent} size="large" open={this.props.openWhen} label="Select User" dismissible>
         {this.state.error ? <div className={css.userError}>{this.state.error}</div> : null}
-        <this.connectedApp {...this.props} onSelectRow={this.passUserOut} onComponentWillUnmount={this.props.onCloseModal} showSingleResult={false} browseOnly />
+        <this.connectedApp {...this.props} packageInfo={packageInfo} onSelectRow={this.passUserOut} onComponentWillUnmount={this.props.onCloseModal} showSingleResult={false} browseOnly />
       </Modal>
     );
   }


### PR DESCRIPTION
This PR passes a correct `packageInfo` into `Users`. This change is required to fix https://issues.folio.org/browse/ERM-72 and it's related to couple additional PRs in ui-users (https://github.com/folio-org/ui-users/pull/761) and `SearchAndSort` (https://github.com/folio-org/stripes-smart-components/pull/450).