### PR TITLE
restore active, inactive filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-plugin-find-user
 
+## 1.7.0 (IN PROGRESS)
+
+* Restore the active, inactive filters a la ui-users.
+
 ## [1.6.0](https://github.com/folio-org/ui-plugin-find-user/tree/v1.6.0) (2019-03-15)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v1.5.0...v1.6.0)
 

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -7,8 +7,8 @@ const filterConfig = [
     name: 'active',
     cql: 'active',
     values: [
-      { name: 'Include inactive users', cql: 'false' },
-      { name: 'Show active users', cql: 'true', hidden: true },
+      { name: 'inactive', cql: 'false' },
+      { name: 'active', cql: 'true' },
     ],
   },
   {

--- a/test/bigtest/interactors/findUser.js
+++ b/test/bigtest/interactors/findUser.js
@@ -23,7 +23,7 @@ import css from '../../../src/UserSearch.css';
 }
 
 @interactor class PluginModalInteractor {
-  clickInactiveUsersCheckbox = clickable('#clickable-filter-active-include-inactive-users');
+  clickInactiveUsersCheckbox = clickable('#clickable-filter-active-inactive');
   clickFacultyCheckbox = clickable('#clickable-filter-pg-faculty');
   clickGraduateCheckbox = clickable('#clickable-filter-pg-graduate');
   clickStaffCheckbox = clickable('#clickable-filter-pg-staff');


### PR DESCRIPTION
The active and inactive filters were restored to ui-users in
/folio-org/ui-users/pull/811. This change restores them here as well.