### PR TITLE
UICHKOUT-509 - Keyboard navigation ignores Patron look-up link

### DIFF
--- a/src/PluginFindUser.js
+++ b/src/PluginFindUser.js
@@ -73,7 +73,6 @@ class PluginFindUser extends Component {
               id={id}
               key="searchButton"
               buttonStyle={searchButtonStyle}
-              tabIndex="-1"
               aria-label={ariaLabel}
               onClick={this.openModal}
               buttonRef={this.modalTrigger}

--- a/test/bigtest/tests/findUser-test.js
+++ b/test/bigtest/tests/findUser-test.js
@@ -61,6 +61,7 @@ describe('UI-plugin-find-user', function () {
 
         describe('resetting the filter and search', function () {
           beforeEach(async function () {
+            await findUser.modal.clickInactiveUsersCheckbox();
             await findUser.modal.resetButton.click();
           });
 


### PR DESCRIPTION
# Purpose
To allow user navigate to patron look-up link by keyboard

# Link
https://issues.folio.org/browse/UICHKOUT-509

#Screenshot
<img width="1440" alt="Screen Shot 2019-06-12 at 13 56 14" src="https://user-images.githubusercontent.com/43472449/59345932-de03ca80-8d19-11e9-9f6b-8f71f8c1e50c.png">
