### PR TITLE
UIPFU-18 provide correct props to AppIcon

### DIFF
--- a/src/UserSearchView.js
+++ b/src/UserSearchView.js
@@ -204,7 +204,7 @@ class UserSearchView extends React.Component {
         <AppIcon
           app="users"
           size="small"
-          className={user.active || css.inactiveAppIcon}
+          className={user.active ? '' : css.inactiveAppIcon}
         >
           {
             user.active


### PR DESCRIPTION
Don't send an unnecessary boolean value to `<AppIcon>`. It generates a
console warning.

Fixes [UIPFU-18](https://issues.folio.org/browse/UIPFU-18)