### PR TITLE
Pass a ref to the Modal instead of the Modal content, refs UIPFU-23

### DIFF
--- a/src/PluginFindUser.js
+++ b/src/PluginFindUser.js
@@ -22,7 +22,7 @@ class PluginFindUser extends Component {
     this.openModal = this.openModal.bind(this);
     this.closeModal = this.closeModal.bind(this);
     this.modalTrigger = React.createRef();
-    this.modalContent = React.createRef();
+    this.modalRef = React.createRef();
   }
 
   getStyle() {
@@ -52,8 +52,8 @@ class PluginFindUser extends Component {
         afterClose();
       }
 
-      if (this.modalContent.current && this.modalTrigger.current) {
-        if (contains(this.modalContent.current, document.activeElement)) {
+      if (this.modalRef.current && this.modalTrigger.current) {
+        if (contains(this.modalRef.current, document.activeElement)) {
           this.modalTrigger.current.focus();
         }
       }
@@ -86,7 +86,7 @@ class PluginFindUser extends Component {
         <UserSearchModal
           openWhen={this.state.openModal}
           closeCB={this.closeModal}
-          contentRef={this.modalContent}
+          modalRef={this.modalRef}
           {...isolatedProps}
         />
       </div>

--- a/src/UserSearchModal.js
+++ b/src/UserSearchModal.js
@@ -31,14 +31,13 @@ class UserSearchModal extends Component {
 
     this.closeModal = this.closeModal.bind(this);
     this.passUserOut = this.passUserOut.bind(this);
-    this.modalContent = props.contentRef || React.createRef();
+    this.modalRef = props.modalRef || React.createRef();
   }
 
   closeModal() {
     this.setState({
       error: null,
-    },
-    () => {
+    }, () => {
       this.props.closeCB();
     });
   }
@@ -68,18 +67,18 @@ class UserSearchModal extends Component {
         enforceFocus={false}
         label={<FormattedMessage id="ui-plugin-find-user.modal.label" />}
         open={this.props.openWhen}
+        ref={this.modalRef}
         size="large"
         onClose={this.closeModal}
       >
         {this.state.error ? <div className={css.userError}>{this.state.error}</div> : null}
         <UserSearchContainer {...this.props} onComponentWillUnmount={this.props.onCloseModal}>
-          { (viewProps) => <UserSearchView
+          {(viewProps) => <UserSearchView
             {...viewProps}
             onSaveMultiple={this.passUsersOut}
             onSelectRow={this.passUserOut}
-            contentRef={this.modalContent}
             isMultiSelect={Boolean(this.props.selectUsers)}
-          /> }
+          />}
         </UserSearchContainer>
       </Modal>
     );


### PR DESCRIPTION
refs UIPFU-23

needs to be merged after https://github.com/folio-org/stripes-components/pull/1115 is merged.

PR targets the ref to the `Modal` instead of the Modals content because the condition [here](https://github.com/folio-org/ui-plugin-find-user/pull/112/files#diff-96e3556dd15eba52e6c744f5d35fd2eeR56) needs to not only consider elements within the Modals content but even outside (the dismissible button in this case). So that when we close a modal by clicking the **X** button the button that triggered the opening of the modal should be back into focus.