### PR TITLE
UIPFU-25 upgrade babel deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,12 +42,13 @@
     "babel-eslint": "^9.0.0",
     "babel-polyfill": "^6.26.0",
     "chai": "^4.2.0",
+    "core-js": "^3.6.4",
     "eslint": "^5.5.0",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
     "react-intl": "^2.7.0",
     "react-router-dom": "^4.0.0",
-    "webpack": "^4.10.2"
+    "regenerator-runtime": "^0.13.3"
   },
   "dependencies": {
     "classnames": "^2.2.5",

--- a/test/bigtest/index.js
+++ b/test/bigtest/index.js
@@ -1,4 +1,5 @@
-import 'babel-polyfill';
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 
 // require all modules ending in "-test" from the current directory and
 // all subdirectories


### PR DESCRIPTION
Upgrade babel deps to those compatible with v7. This is part of a
project-wide effort to update the build infrastructure.

Refs [UIPFU-25](https://issues.folio.org/browse/UIPFU-25)