### PR TITLE
STCOR-148 migrate to actsAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.0.0 (IN PROGRESS)
 
 * update to `@folio/stripes` `v3.0.0`.
+* Migrate from `stripes.type` to `stripes.actsAs`
 
 ## [1.9.1](https://github.com/folio-org/ui-plugin-find-user/tree/v1.9.1) (2019-12-04)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v1.9.0...v1.9.1)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node": ">=6.0.0"
   },
   "stripes": {
-    "type": "plugin",
+    "actsAs": ["plugin"],
     "pluginType": "find-user",
     "displayName": "ui-plugin-find-user.meta.title",
     "queryResource": "query",


### PR DESCRIPTION
A stripes module can be more than one type, presenting an array in
`actsAs` rather than a single string to `type`.

Refs [STCOR-148](https://issues.folio.org/browse/STCOR-148)