### PR TITLE
STCOM-677 tests must handle MCL internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.0.0](IN PROGRESS)
 
 * Update to `stripes v4.0.0`
+* Update tests to accomodate `<MCL>` changes in [PR #1205](folio-org/stripes-components/pull/1205)
 
 ## [2.0.1](https://github.com/folio-org/ui-plugin-find-user/tree/v2.0.1) (2020-04-06)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v2.0.0...v2.0.1)

--- a/test/bigtest/interactors/findUser.js
+++ b/test/bigtest/interactors/findUser.js
@@ -29,8 +29,8 @@ import css from '../../../src/UserSearch.css';
   clickStaffCheckbox = clickable('#clickable-filter-pg-staff');
   clickUndergradCheckbox = clickable('#clickable-filter-pg-undergrad');
 
-  instances = collection('[role="group"] [role="row"]', {
-    click: clickable(),
+  instances = collection('[role="rowgroup"] [role="row"]', {
+    click: clickable('[role=gridcell]'),
     hasCheckbox: isPresent('input[type=checkbox]'),
     check: clickable('input[type=checkbox]'),
   });


### PR DESCRIPTION
`<MCL>` DOM structure changed a bit in
[PR #1205](folio-org/stripes-components/pull/1205) so we need to
accommodate that here.

Refs [STCOM-677](https://issues.folio.org/browse/STCOM-677)