### PR TITLE
UIPFU-24: update eslint to >= 6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [3.0.0](https://github.com/folio-org/ui-plugin-find-user/tree/v3.0.0) (2020-06-09)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v2.0.1...v3.0.0)
 
+* Update eslint to version 6.2.1 Fixes UIPFU-24
 * Update to `stripes v4.0.0`
 * Update tests to accomodate `<MCL>` changes in [PR #1205](folio-org/stripes-components/pull/1205)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Change history for ui-plugin-find-user
 
+
+## 3.1.0 (IN PROGRESS)
+
+* Update eslint to version 6.2.1. Fixes UIPFU-24
+
 ## [3.0.0](https://github.com/folio-org/ui-plugin-find-user/tree/v3.0.0) (2020-06-09)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v2.0.1...v3.0.0)
 
-* Update eslint to version 6.2.1 Fixes UIPFU-24
 * Update to `stripes v4.0.0`
 * Update tests to accomodate `<MCL>` changes in [PR #1205](folio-org/stripes-components/pull/1205)
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babel-eslint": "^9.0.0",
     "chai": "^4.2.0",
     "core-js": "^3.6.4",
-    "eslint": "^5.5.0",
+    "eslint": "^6.2.1",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
     "react-intl": "^4.5.3",


### PR DESCRIPTION
I updated the eslint version in package.json.  I then re-ran yarn lint
to make sure the new version didn't flag any problems with the existing
 code.

Refs: https://issues.folio.org/browse/UIPFU-24