### PR TITLE
UIPFU-28: Can't filter requester lookup by patron group with commas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update eslint to version 6.2.1. Fixes UIPFU-24
 * Updated to react-intl version 4.7.1
+* Modified how patron group names are displayed in filter menu. Fixes UIPFU-28
 
 ## [3.0.0](https://github.com/folio-org/ui-plugin-find-user/tree/v3.0.0) (2020-06-09)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v2.0.1...v3.0.0)

--- a/src/UserSearchContainer.js
+++ b/src/UserSearchContainer.js
@@ -110,7 +110,7 @@ class UserSearchContainer extends React.Component {
     if (pg.length) {
       const pgFilterConfig = filterConfig.find(group => group.name === 'pg');
       const oldValuesLength = pgFilterConfig.values.length;
-      pgFilterConfig.values = pg.map(rec => ({ name: rec.group, cql: rec.id }));
+      pgFilterConfig.values = pg.map(rec => ({ name: encodeURIComponent(rec.group), displayName: rec.group, cql: rec.id }));
       if (oldValuesLength === 0) {
         this.props.mutator.initializedFilterConfig.replace(true); // triggers refresh of users
       }

--- a/src/filterConfig.js
+++ b/src/filterConfig.js
@@ -23,7 +23,7 @@ const filterConfig = [
     label: <FormattedMessage id="ui-plugin-find-user.information.patronGroup" />,
     name: 'pg',
     cql: 'patronGroup',
-    values: [], // will be filled in by componentWillUpdate
+    values: [], // will be filled in by componentDidUpdate
   },
 ];
 


### PR DESCRIPTION
Addressed this by defining a separate displayName in the FiterGroup
values when they are mapped on component load, which displays the
unmodified user group name.  Then wrapped a javascript encodeURIComponent
function around the internal identifier group name
to encode any special characters (such as spaces and commas).
This seems to have fixed the problem, user groups with commas in the
names can now be selected normally and will pull up user names in the
modal.

Refs: https://issues.folio.org/browse/UIPFU-28