### PR TITLE
UIPFU-30 update @folio/stripes to v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Change history for ui-plugin-find-user
 
-## 3.1.0 (IN PROGRESS)
+## 4.0.0 (IN PROGRESS)
 
 * Update eslint to version 6.2.1. Fixes UIPFU-24
-* Updated to react-intl version 4.7.1
 * Modified how patron group names are displayed in filter menu. Fixes UIPFU-28
 * Refactor from `bigtest/mirage` to `miragejs`
+* Update to `@folio/stripes` `v5` including `react-intl` `v5.7` and `react-router` `v5.1`. Refs UIPFU-30.
 
 ## [3.0.0](https://github.com/folio-org/ui-plugin-find-user/tree/v3.0.0) (2020-06-09)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v2.0.1...v3.0.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/plugin-find-user",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "User-finder for Stripes",
   "repository": "folio-org/ui-plugin-find-user",
   "publishConfig": {
@@ -37,9 +37,9 @@
     "@bigtest/mocha": "^0.5.2",
     "@bigtest/react": "^0.1.2",
     "@folio/eslint-config-stripes": "^3.2.0",
-    "@folio/stripes": "^4.0.0",
-    "@folio/stripes-cli": "^1.10.0",
-    "@folio/stripes-core": "^5.0.0",
+    "@folio/stripes": "^5.0.0",
+    "@folio/stripes-cli": "^1.18.0",
+    "@folio/stripes-core": "^6.0.0",
     "babel-eslint": "^9.0.0",
     "chai": "^4.2.0",
     "core-js": "^3.6.4",
@@ -49,8 +49,8 @@
     "miragejs": "^0.1.40",
     "react": "^16.5.0",
     "react-dom": "^16.5.0",
-    "react-intl": "^4.7.1",
-    "react-router-dom": "^4.0.0",
+    "react-intl": "^5.7.0",
+    "react-router-dom": "^5.1.0",
     "regenerator-runtime": "^0.13.3"
   },
   "dependencies": {
@@ -60,9 +60,9 @@
     "prop-types": "^15.6.0"
   },
   "peerDependencies": {
-    "@folio/stripes": "^4.0.0",
+    "@folio/stripes": "^5.0.0",
     "react": "*",
-    "react-intl": "^4.5.3",
-    "react-router-dom": "^4.0.0"
+    "react-intl": "^5.7.0",
+    "react-router-dom": "^5.1.0"
   }
 }


### PR DESCRIPTION
Update `@folio/stripes` to `v5`, which also includes updates to
`react-intl` `v5.7` and `react-router` `v5.1`.

Refs [UIPFU-30](https://issues.folio.org/browse/UIPFU-30)