### PR TITLE
UIPFU-33 retrieve up to 200 patron groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-plugin-find-user
 
+## 4.0.1 IN PROGRESS
+
+* Retrieve up to 200 patron groups, just like ui-users. Refs UIPFU-33.
+
 ## [4.0.0](https://github.com/folio-org/ui-plugin-find-user/tree/v4.0.0) (2020-10-09)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v3.0.0...v4.0.0)
 

--- a/src/UserSearchContainer.js
+++ b/src/UserSearchContainer.js
@@ -56,7 +56,7 @@ class UserSearchContainer extends React.Component {
       path: 'groups',
       params: {
         query: 'cql.allRecords=1 sortby group',
-        limit: '40',
+        limit: '200',
       },
       records: 'usergroups',
     }


### PR DESCRIPTION
Retrieve up to 200 patron groups, the same limit set in [ui-users](https://github.com/folio-org/ui-users/blob/993b5a902244b2b418e62f6b1021e0ace28ad282/src/routes/UserSearchContainer.js).

Refs [UIPFU-33](https://issues.folio.org/browse/UIPFU-33)