### PR TITLE
UIPFU-35: Use offset to request result list pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Retrieve up to 200 patron groups, just like ui-users. Refs UIPFU-33.
 * It's election day in the USA. Vote!
+* Use `offset` to request result list pages, just like in ui-users. Fixes UIPFU-35.
 
 ## [4.0.0](https://github.com/folio-org/ui-plugin-find-user/tree/v4.0.0) (2020-10-09)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v3.0.0...v4.0.0)

--- a/src/Filters.js
+++ b/src/Filters.js
@@ -10,16 +10,32 @@ export default class Filters extends React.Component {
     activeFilters: PropTypes.object,
     onChangeHandlers: PropTypes.object.isRequired,
     config: PropTypes.arrayOf(PropTypes.object),
+    resultOffset: PropTypes.shape({
+      replace: PropTypes.func.isRequired,
+    }),
   };
 
   static defaultProps = {
     activeFilters: {},
   }
 
+  handleFilterChange = e => {
+    const {
+      resultOffset,
+      onChangeHandlers,
+    } = this.props;
+
+    if (resultOffset) {
+      resultOffset.replace(0);
+    }
+
+    onChangeHandlers.checkbox(e);
+  }
+
   render() {
     const {
       activeFilters,
-      onChangeHandlers: { checkbox, clearGroup },
+      onChangeHandlers: { clearGroup },
       config,
     } = this.props;
 
@@ -30,7 +46,7 @@ export default class Filters extends React.Component {
       <FilterGroups
         config={config}
         filters={groupFilters}
-        onChangeFilter={checkbox}
+        onChangeFilter={this.handleFilterChange}
         onClearFilter={clearGroup}
       />
     );

--- a/src/UserSearchView.js
+++ b/src/UserSearchView.js
@@ -64,6 +64,9 @@ class UserSearchView extends React.Component {
     data: PropTypes.object,
     onNeedMoreData: PropTypes.func,
     visibleColumns: PropTypes.arrayOf(PropTypes.string),
+    resultOffset: PropTypes.shape({
+      replace: PropTypes.func.isRequired,
+    }),
   }
 
   static defaultProps = {
@@ -167,6 +170,7 @@ class UserSearchView extends React.Component {
       data,
       contentRef,
       isMultiSelect,
+      resultOffset,
     } = this.props;
     const { checkedMap, isAllChecked } = this.state;
 
@@ -313,6 +317,7 @@ class UserSearchView extends React.Component {
                                 onChangeHandlers={getFilterHandlers()}
                                 activeFilters={activeFilters}
                                 config={filterConfig}
+                                resultOffset={resultOffset}
                               />
                             </form>
                           </Pane>
@@ -354,6 +359,8 @@ class UserSearchView extends React.Component {
                             isEmptyMessage={resultsStatusMessage}
                             autosize
                             virtualize
+                            pageAmount={100}
+                            pagingType="click"
                           />
 
                         </Pane>


### PR DESCRIPTION
https://issues.folio.org/browse/UIPFU-35

### Purpose
Fix the inconsistent search result count in the user search popup.

### Approach
There are two ways.
The first is to try to repair the implemented one (using `resultCount`, which re-requests all previously fetched pages).
The second way is to implement the approach (using `offset`) that successfully fixed this issue in `ui-users`.
In this PR, the second path was chosen.

![Screen Shot 2020-11-16 at 11 26 12](https://user-images.githubusercontent.com/49517355/99261121-f3d9c100-2824-11eb-95db-87ee4fbc80c6.png)
