### PR TITLE
UIU-2503: Display preferred name in Checkout and Requests user modal

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
   "parser": "babel-eslint",
-  "extends": "@folio/eslint-config-stripes"
+  "extends": "@folio/eslint-config-stripes",
+  "rules": {
+    "react/jsx-one-expression-per-line": 0
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,4 @@
 {
   "parser": "babel-eslint",
-  "extends": "@folio/eslint-config-stripes",
-  "rules": {
-    "react/jsx-one-expression-per-line": 0
-  }
+  "extends": "@folio/eslint-config-stripes"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [6.0.0](https://github.com/folio-org/ui-plugin-find-user/tree/v6.0.0) (2021-10-09)
 
 * Update to `@folio/stripes` `v7.0.0`. UIPFU-44.
+* Display preferred name in the user search modal in Checkout and Requests. UIU-2503.
 
 ## [5.0.1](https://github.com/folio-org/ui-plugin-find-user/tree/v5.0.1) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v5.0.0...v5.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Change history for ui-plugin-find-user
 
+## 6.1.0 (IN PROGRESS)
+
+* Display preferred name in the user search modal in Checkout and Requests. UIU-2503.
+
 ## [6.0.0](https://github.com/folio-org/ui-plugin-find-user/tree/v6.0.0) (2021-10-09)
 
 * Update to `@folio/stripes` `v7.0.0`. UIPFU-44.
-* Display preferred name in the user search modal in Checkout and Requests. UIU-2503.
 
 ## [5.0.1](https://github.com/folio-org/ui-plugin-find-user/tree/v5.0.1) (2021-06-18)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v5.0.0...v5.0.1)

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "chai": "^4.2.0",
     "core-js": "^3.6.4",
     "eslint": "^6.2.1",
+    "eslint-import-resolver-webpack": "^0.13.2",
     "faker": "^4.1.0",
     "inflected": "^2.0.4",
     "miragejs": "^0.1.40",

--- a/src/UserSearchView.js
+++ b/src/UserSearchView.js
@@ -33,8 +33,13 @@ import css from './UserSearch.css';
 
 function getFullName(user) {
   const lastName = get(user, ['personal', 'lastName'], '');
-  const firstName = get(user, ['personal', 'firstName'], '');
+  let firstName = get(user, ['personal', 'firstName'], '');
   const middleName = get(user, ['personal', 'middleName'], '');
+  const preferredFirstName = get(user, ['personal', 'preferredFirstName'], '');
+
+  if (preferredFirstName && firstName) {
+    firstName = `${preferredFirstName} (${firstName})`;
+  }
 
   return `${lastName}${firstName ? ', ' : ' '}${firstName} ${middleName}`;
 }
@@ -297,6 +302,7 @@ class UserSearchView extends React.Component {
                                   disabled={(!searchValue.query || searchValue.query === '')}
                                   data-test-user-search-submit
                                 >
+
                                   Search
                                 </Button>
                               </div>

--- a/src/UserSearchView.js
+++ b/src/UserSearchView.js
@@ -32,10 +32,10 @@ import Filters from './Filters';
 import css from './UserSearch.css';
 
 function getFullName(user) {
-  const lastName = get(user, ['personal', 'lastName'], '');
-  let firstName = get(user, ['personal', 'firstName'], '');
-  const middleName = get(user, ['personal', 'middleName'], '');
-  const preferredFirstName = get(user, ['personal', 'preferredFirstName'], '');
+  let firstName = user?.personal?.firstName ?? '';
+  const lastName = user?.personal?.lastName ?? '';
+  const middleName = user?.personal?.middleName ?? '';
+  const preferredFirstName = user?.personal?.preferredFirstName ?? '';
 
   if (preferredFirstName && firstName) {
     firstName = `${preferredFirstName} (${firstName})`;
@@ -302,8 +302,7 @@ class UserSearchView extends React.Component {
                                   disabled={(!searchValue.query || searchValue.query === '')}
                                   data-test-user-search-submit
                                 >
-
-                                  Search
+                                  <FormattedMessage id="ui-plugin-find-user.searchFieldLabel" />
                                 </Button>
                               </div>
                               <div className={css.resetButtonWrap}>


### PR DESCRIPTION
## Purpose
- Display preferred name in the user search modal in Checkout and Requests
- If user has `preferredFirstName` then display `LastName`, `PreferredFirstName` `(FirstName)` `MiddleName` in result list
- if user doesn't have  `preferredFirstName` then display `LastName`, `FirstName` `MiddleName` in result list
- Refs: https://issues.folio.org/browse/UIU-2503

## Approach
- Refactor `getFullName` function to include `preferredFirstName`
- Added `eslint-import-resolver-webpack` plugin to resolve eslint error `unable to resolve path to module`. See in screenshots

## Screenshots
<img src="https://user-images.githubusercontent.com/89512426/154093998-6d1ce69a-1533-4d17-ab90-e781dff171c4.png" width="250" height="200" />  <img src="https://user-images.githubusercontent.com/89512426/154094250-85662fcc-29ff-403a-be31-32a2614625a5.png" width="250" height="200" /> <img src="https://user-images.githubusercontent.com/89512426/154095669-3930ba6e-e501-46b6-afb2-438ce2a360da.png" width="250" height="200" />



