### PR TITLE
UIPFU-48: Resolve problem with focus after modal close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [6.2.0] IN PROGRESS
 
+* Resolve problem with focus after modal close. UIPFU-48.
+
 ## [6.1.0](https://github.com/folio-org/ui-plugin-find-user/tree/v6.1.0) (2022-03-03)
 
 * Display preferred name in the user search modal in Checkout and Requests. UIPFU-47.

--- a/src/UserSearchModal.js
+++ b/src/UserSearchModal.js
@@ -21,7 +21,12 @@ class UserSearchModal extends Component {
     dataKey: PropTypes.string,
     contentRef: PropTypes.object,
     modalRef: PropTypes.object,
+    restoreFocus: PropTypes.bool
   }
+
+  static defaultProps = {
+    restoreFocus: true,
+  };
 
   constructor(props) {
     super(props);
@@ -61,25 +66,32 @@ class UserSearchModal extends Component {
   }
 
   render() {
+    const {
+      restoreFocus,
+      onCloseModal,
+      openWhen,
+      selectUsers,
+    } = this.props;
+
     return (
       <Modal
         contentClass={css.modalContent}
         dismissible
         enforceFocus={false}
         label={<FormattedMessage id="ui-plugin-find-user.modal.label" />}
-        open={this.props.openWhen}
+        open={openWhen}
         ref={this.modalRef}
         size="large"
         onClose={this.closeModal}
-        restoreFocus={false}
+        restoreFocus={restoreFocus}
       >
         {this.state.error ? <div className={css.userError}>{this.state.error}</div> : null}
-        <UserSearchContainer {...this.props} onComponentWillUnmount={this.props.onCloseModal}>
+        <UserSearchContainer {...this.props} onComponentWillUnmount={onCloseModal}>
           {(viewProps) => <UserSearchView
             {...viewProps}
             onSaveMultiple={this.passUsersOut}
             onSelectRow={this.passUserOut}
-            isMultiSelect={Boolean(this.props.selectUsers)}
+            isMultiSelect={Boolean(selectUsers)}
           />}
         </UserSearchContainer>
       </Modal>

--- a/src/UserSearchModal.js
+++ b/src/UserSearchModal.js
@@ -71,6 +71,7 @@ class UserSearchModal extends Component {
         ref={this.modalRef}
         size="large"
         onClose={this.closeModal}
+        restoreFocus={false}
       >
         {this.state.error ? <div className={css.userError}>{this.state.error}</div> : null}
         <UserSearchContainer {...this.props} onComponentWillUnmount={this.props.onCloseModal}>


### PR DESCRIPTION
## Purpose
We have feedback from customer, that in the `ui-checkout` module when patron is set using `find-user` plugin, sometimes plugin button `Patron look-up` becomes focused instead of `item barcode` input.

I investigated this problem and found out that the issue is reproducible only with fast internet connection.

When we select user in `find-user` plugin modal then this modal is closed. When this modal is closed it restores focus to element which had focus before opening modal(in our case it is button `Patron look-up`). Then patron info is loaded from backend and after that we set focus to `item barcode` input.
But sometimes(when you have fast internet connection) patron info is loaded before modal becomes closed. So in this case we first set focus to `item barcode` input then modal becomes closed and modal restore focus to button `Patron look-up`.

As customer wish, when patron is selected and modal is closed, focus should be on `item barcode` input in any case.

**UPDATED**:
button `Patron look-up` get focus twice. First time [here https://github.com/folio-org/ui-plugin-find-user/blob/master/src/PluginFindUser.js#L55-L59](https://github.com/folio-org/ui-plugin-find-user/blob/master/src/PluginFindUser.js#L55-L59) when we start closing modal

and second time [here https://github.com/react-bootstrap/react-overlays/blob/master/src/Modal.tsx#L229](https://github.com/react-bootstrap/react-overlays/blob/master/src/Modal.tsx#L229) when modal is fully closed(unmounted after animation in approximately 1 second) and **handleHide** method is executed

## Approach
We found out that we can fix this issue if we add `restoreFocus={false}` property to `Modal` component.
But we also found out that this plugin is used in many places in different modules, and we can't be sure, that this change will not affect such places.

So we have two options:
1) set `restoreFocus={false}` property like we did in this pull request and check all other places where `find-user` plugin is used to be sure that we did not break anything.
2) we need to extend `ui-plugin-find-user` to be able to pass properties to `Modal` component to be able to pass `restoreFocus={false}` only for our place.

## Refs
https://issues.folio.org/browse/UIPFU-48