### PR TITLE
UIPFU-55 also query against preferredName, customFields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 6.3.0 IN PROGRESS
 
+* Also query against `personal.preferredFirstName` and `customFields`. UIPFU-55.
+
 ## [6.2.0](https://github.com/folio-org/ui-plugin-find-user/tree/v6.2.0) (2022-06-28)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v6.1.0...v6.2.0)
 

--- a/src/UserSearchContainer.js
+++ b/src/UserSearchContainer.js
@@ -27,7 +27,7 @@ const queryFields = [
 ];
 
 const compileQuery = template(
-  `(${queryFields.map(f => `${f}="%{query}*"`).join(" or ")})`,
+  `(${queryFields.map(f => `${f}="%{query}*"`).join(' or ')})`,
   { interpolate: /%{([\s\S]+?)}/g }
 );
 

--- a/src/UserSearchContainer.js
+++ b/src/UserSearchContainer.js
@@ -13,8 +13,21 @@ import filterConfig from './filterConfig';
 const INITIAL_RESULT_COUNT = 30;
 const RESULT_COUNT_INCREMENT = 30;
 
+// list of fields to query against
+const queryFields = [
+  'username',
+  'personal.firstName',
+  'personal.preferredFirstName',
+  'personal.lastName',
+  'personal.email',
+  'barcode',
+  'id',
+  'externalSystemId',
+  'customFields'
+];
+
 const compileQuery = template(
-  '(username="%{query}*" or personal.firstName="%{query}*" or personal.lastName="%{query}*" or personal.email="%{query}*" or barcode="%{query}*" or id="%{query}*" or externalSystemId="%{query}*")',
+  `(${queryFields.map(f => `${f}="%{query}*"`).join(" or ")})`,
   { interpolate: /%{([\s\S]+?)}/g }
 );
 


### PR DESCRIPTION
When conducting a search, query against the same fields as the users
app. This means adding

* `personal.preferredFirstName`
* `customFields`

Refs [UIPFU-55](https://issues.folio.org/browse/UIPFU-55)