### PR TITLE
UIPFU-59: Use group id instead of group name when filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v6.2.0...v6.3.0)
 
 * Also query against `personal.preferredFirstName` and `customFields`. UIPFU-55.
+* Use group id instead of group name when filtering. Fixes UIPFU-59.
 
 ## [6.2.0](https://github.com/folio-org/ui-plugin-find-user/tree/v6.2.0) (2022-06-28)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v6.1.0...v6.2.0)

--- a/src/Filters.js
+++ b/src/Filters.js
@@ -42,6 +42,8 @@ export default class Filters extends React.Component {
     const groupFilters = {};
     activeFilters.string.split(',').forEach(m => { groupFilters[m] = true; });
 
+    console.log(config, groupFilters);
+
     return (
       <FilterGroups
         config={config}

--- a/src/Filters.js
+++ b/src/Filters.js
@@ -42,8 +42,6 @@ export default class Filters extends React.Component {
     const groupFilters = {};
     activeFilters.string.split(',').forEach(m => { groupFilters[m] = true; });
 
-    console.log(config, groupFilters);
-
     return (
       <FilterGroups
         config={config}

--- a/src/UserSearchContainer.js
+++ b/src/UserSearchContainer.js
@@ -127,7 +127,7 @@ class UserSearchContainer extends React.Component {
     if (pg.length) {
       const pgFilterConfig = filterConfig.find(group => group.name === 'pg');
       const oldValuesLength = pgFilterConfig.values.length;
-      pgFilterConfig.values = pg.map(rec => ({ name: encodeURIComponent(rec.group), displayName: rec.group, cql: rec.id }));
+      pgFilterConfig.values = pg.map(rec => ({ name: encodeURIComponent(rec.id), displayName: rec.group, cql: rec.id }));
       if (oldValuesLength === 0) {
         this.props.mutator.initializedFilterConfig.replace(true); // triggers refresh of users
       }


### PR DESCRIPTION
https://issues.folio.org/browse/UIPFU-59

Use group id instead of group name when filtering.