### PR TITLE
UIPFU-58 - Add middle name to keyword search for Users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-plugin-find-user
 
 ## 6.5.0 IN PROGRESS
+* Add middle name to keyword search for Users. Refs UIPFU-58.
 
 ## [6.4.0](https://github.com/folio-org/ui-plugin-find-user/tree/v6.4.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v6.3.0...v6.4.0)

--- a/src/UserSearchContainer.js
+++ b/src/UserSearchContainer.js
@@ -19,6 +19,7 @@ const queryFields = [
   'personal.firstName',
   'personal.preferredFirstName',
   'personal.lastName',
+  'personal.middleName',
   'personal.email',
   'barcode',
   'id',


### PR DESCRIPTION
## Purpose
Add middle name to keyword search for Users

## Approach
Add personal.middleName to queryFields list.

## Screenshots
![W80w0YYzq7](https://user-images.githubusercontent.com/104053200/236170741-53a06b8f-d209-47b4-82aa-6a6ec8f4e689.gif)


## Ref
https://issues.folio.org/browse/UIPFU-58
