### PR TITLE
UIPFU-75: fix the number of selected users length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add Initial Selected Users list. Refs UIPFU-71.
 * Leverage `yarn.lock`. Refs UIPFU-72.
 * Add PULL_REQUEST_TEMPLATE.md file to the repository. Refs UIPFU-68.
+* Fix selected users length. Refs UIPFU-75.
 
 ## [6.4.0](https://github.com/folio-org/ui-plugin-find-user/tree/v6.4.0) (2023-02-20)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v6.3.0...v6.4.0)

--- a/src/UserSearchView.js
+++ b/src/UserSearchView.js
@@ -192,7 +192,7 @@ class UserSearchView extends React.Component {
     const { checkedMap, isAllChecked } = this.state;
 
     const { patronGroups, users } = data;
-    const checkedUsersLength = Object.keys(checkedMap).length;
+    const checkedUsersLength = Object.values(checkedMap).filter(Boolean).length;
     const builtVisibleColumns = isMultiSelect ? ['isChecked', ...visibleColumns] : visibleColumns;
 
     const query = queryGetter ? queryGetter() || {} : {};

--- a/test/bigtest/tests/findUser-test.js
+++ b/test/bigtest/tests/findUser-test.js
@@ -183,9 +183,17 @@ describe('UI-plugin-find-user', function () {
         });
       });
 
-      describe('with initial selected users', function () {
-        it('returns selected users', function () {
-          expect(selectedUsers.length).to.equal(2);
+      describe('unselect users', function () {
+        beforeEach(async function () {
+          selectedUsers = [];
+          await findUser.modal.instances(1).check();
+          await findUser.modal.instances(3).check();
+          await findUser.modal.instances(3).check();
+          await findUser.modal.saveMultipleButton.click();
+        });
+
+        it('returns selected users after unselect a user', function () {
+          expect(selectedUsers.length).to.equal(1);
         });
       });
     });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIPFU-2 Add ability to customize search button
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIPFU-2
 -->
[UIPFU-75](https://issues.folio.org/browse/UIPFU-75)
The issue was caused due to the value of unchecked users' value to `null`
![Screenshot 2023-08-16 at 5 04 28 PM](https://github.com/folio-org/ui-plugin-find-user/assets/116072773/3a05490b-9d43-48d9-a094-b83570698c94)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- fix `checkedUsersLength` 
- 
#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

https://github.com/folio-org/ui-plugin-find-user/assets/116072773/33cb0891-0cdb-496e-a717-3fc761578ae3

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
