### PR TITLE
UIPFU-76 Revert - ECS - 'Do not display shadow users in search results'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 * Add PULL_REQUEST_TEMPLATE.md file to the repository. Refs UIPFU-68.
 * Update Node.js to v18 in GitHub Actions. Refs. UIPFU-73.
 * Fix selected users length. Refs UIPFU-75.
-* ECS - Do not display shadow users in search results. Refs UIPFU-76.
 * Support fetch users from different tenants. Refs UIPFU-74.
 * *BREAKING* bump `react-intl` to `v6.4.4`. Refs UIPFU-79.
 

--- a/src/UserSearchContainer.js
+++ b/src/UserSearchContainer.js
@@ -8,7 +8,6 @@ import {
   StripesConnectedSource,
 } from '@folio/stripes/smart-components';
 
-import { NOT_SHADOW_USER_CQL } from './constants';
 import filterConfig from './filterConfig';
 
 const INITIAL_RESULT_COUNT = 30;
@@ -33,27 +32,6 @@ const compileQuery = template(
   { interpolate: /%{([\s\S]+?)}/g }
 );
 
-export function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
-  const mainQuery = makeQueryFunction(
-    'cql.allRecords=1',
-    (_parsedQuery, _props, localProps) => localProps.query.query.trim().split(/\s+/).map(query => compileQuery({ query })).join(' and '),
-    {
-      // the keys in this object must match those passed to
-      // SearchAndSort's columnMapping prop
-      'active': 'active',
-      'name': 'personal.lastName personal.firstName',
-      'patronGroup': 'patronGroup.group',
-      'username': 'username',
-      'barcode': 'barcode',
-      'email': 'personal.email',
-    },
-    filterConfig,
-    2,
-  )(queryParams, pathComponents, resourceData, logger, props);
-
-  return mainQuery && `${NOT_SHADOW_USER_CQL} and ${mainQuery}`;
-}
-
 class UserSearchContainer extends React.Component {
   static manifest = Object.freeze({
     initializedFilterConfig: { initialValue: false },
@@ -68,7 +46,24 @@ class UserSearchContainer extends React.Component {
       perRequest: 100,
       path: 'users',
       GET: {
-        params: { query: buildQuery },
+        params: {
+          query: makeQueryFunction(
+            'cql.allRecords=1',
+            (parsedQuery, props, localProps) => localProps.query.query.trim().split(/\s+/).map(query => compileQuery({ query })).join(' and '),
+            {
+              // the keys in this object must match those passed to
+              // SearchAndSort's columnMapping prop
+              'active': 'active',
+              'name': 'personal.lastName personal.firstName',
+              'patronGroup': 'patronGroup.group',
+              'username': 'username',
+              'barcode': 'barcode',
+              'email': 'personal.email',
+            },
+            filterConfig,
+            2,
+          ),
+        },
         staticFallback: { params: {} },
       },
     },

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,5 +3,3 @@ export const USER_TYPES = {
   SHADOW: 'shadow',
   STAFF: 'staff',
 };
-
-export const NOT_SHADOW_USER_CQL = `((cql.allRecords=1 NOT type ="") or type<>"${USER_TYPES.SHADOW}")`;

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,0 @@
-export const USER_TYPES = {
-  PATRON: 'patron',
-  SHADOW: 'shadow',
-  STAFF: 'staff',
-};

--- a/test/bigtest/tests/findUser-test.js
+++ b/test/bigtest/tests/findUser-test.js
@@ -3,8 +3,6 @@ import { describe, beforeEach, it } from '@bigtest/mocha';
 import { expect } from 'chai';
 import PropTypes from 'prop-types';
 
-import { NOT_SHADOW_USER_CQL } from '../../../src/constants';
-import { buildQuery } from '../../../src/UserSearchContainer';
 import setupApplication, { mount } from '../helpers/helpers';
 import PluginHarness from '../helpers/PluginHarness';
 import FindUserInteractor from '../interactors/findUser';
@@ -259,24 +257,5 @@ describe('UsersShape PropTypes', () => {
       'TestComponent'
     );
     expect(result).to.equal(undefined);
-  });
-
-  describe('buildQuery', () => {
-    const queryParams = {
-      filters: 'active.active',
-      query: 'Joe',
-      sort: 'name',
-    };
-    const pathComponents = {};
-    const resourceData = {
-      query: queryParams,
-    };
-    const logger = {
-      log: () => {},
-    };
-
-    it('should exclude shadow users when building CQL query', () => {
-      expect(buildQuery(queryParams, pathComponents, resourceData, logger)).contain(NOT_SHADOW_USER_CQL);
-    });
   });
 });


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIPFU-2 Add ability to customize search button
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIPFU-2
 -->
https://issues.folio.org/browse/UIPFU-76

As far as the "User type" filter was [implemented](https://github.com/folio-org/ui-users/pull/2555) for the user search and currently includes "shadow" users in the results, the plugin's changes were reverted to keep consistency in the query (This ticket originally was created for consistency purposes).

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
Revert https://github.com/folio-org/ui-plugin-find-user/pull/241

## Screenshots

https://github.com/folio-org/ui-plugin-find-user/assets/88109087/5205968c-27e3-433b-ab25-1907455a58bd

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
