### PR TITLE
UIPFU-95 - Use keywords CQL field for keyword user search.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@
 ## 7.2.0 IN PROGRESS
 
 * Create Jest test environment and setup initial mocks. Refs UIPFU-78.
+* Apply Prev/Next Pagination. Refs UIPFU-49.
+* Use keywords CQL field for keyword user search. Ref UIPFU-95.
 
 ## [7.1.1](https://github.com/folio-org/ui-plugin-find-user/tree/v7.1.1) (2024-05-03)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v7.1.0...v7.1.1)
 
 * Fix Select User Modal with User Assignment Status Filters pagination issue. Refs UIPFU-87.
 * Fix select all toggle button issue. Refs UIPFU-89.
-* Apply Prev/Next Pagination. Refs UIPFU-49.
 
 ## [7.1.0](https://github.com/folio-org/ui-plugin-find-user/tree/v7.1.0) (2024-03-20)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v7.0.0...v7.1.0)

--- a/src/UserSearchContainer.js
+++ b/src/UserSearchContainer.js
@@ -34,15 +34,17 @@ const queryFields = [
   'customFields'
 ];
 
-const compileQuery = template(
-  `(${queryFields.map(f => `${f}="%{query}*"`).join(' or ')})`,
-  { interpolate: /%{([\s\S]+?)}/g }
-);
-
 export function buildQuery(queryParams, pathComponents, resourceData, logger, props) {
   const filters = props.initialSelectedUsers ? filterConfigWithUserAssignedStatus : filterConfig;
   const updatedResourceData = props.initialSelectedUsers &&
     resourceData?.query?.filters?.includes(UAS) ? updateResourceData(resourceData) : resourceData;
+
+  const compileQuery = props.stripes.hasInterface('users', '16.3') ?
+    template('keywords="%{query}*"', { interpolate: /%{([\s\S]+?)}/g }) :
+    template(
+      `(${queryFields.map(f => `${f}="%{query}*"`).join(' or ')})`,
+      { interpolate: /%{([\s\S]+?)}/g }
+    );
 
   return makeQueryFunction(
     'cql.allRecords=1',


### PR DESCRIPTION
## Purpose
[UIPFU-95](https://folio-org.atlassian.net/browse/UIPFU-95) - Use keywords CQL field for keyword user search

## Approach
The /users API has a new CQL search index keywords that significantly speeds up the search. This [implementation](https://folio-org.atlassian.net/browse/MODUSERS-457) bumped up users interface from 16.2 to 16.3 and it is backwards compatible.

Hence search query is updated to leverage the new search index.

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [x] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
