### PR TITLE
UIPFU-115: Fix the algorithm for marking all users as checked/unchecked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-plugin-find-user
 
+## In progress
+* Fix the algorithm for marking all users as checked/unchecked. Refs UIPFU-115. 
+
 ## [8.0.0] (https://github.com/folio-org/ui-plugin-find-user/tree/v8.0.0) (2025-03-13)
 [Full Changelog](https://github.com/folio-org/ui-plugin-find-user/compare/v7.2.0...v8.0.0)
 

--- a/src/UserSearchView.js
+++ b/src/UserSearchView.js
@@ -119,9 +119,10 @@ const UserSearchView = ({
   };
 
   const toggleAll = () => {
-    setIsAllChecked(!isAllChecked);
+    const prevCheckedState = isAllChecked;
+    setIsAllChecked(!prevCheckedState);
 
-    const newCheckedMap = reduceUsersToMap(users.records, isAllChecked);
+    const newCheckedMap = reduceUsersToMap(users.records, !prevCheckedState);
     setCheckedMap(newCheckedMap);
   };
 

--- a/src/UserSearchView.test.js
+++ b/src/UserSearchView.test.js
@@ -81,8 +81,7 @@ describe('UserSearchView', () => {
     await waitFor(() => expect(getByTestId('row-checked')).toBeChecked());
 
     // first click checks all entries, second unchecks all entries
-    userEvent.click(getByTestId('toggle-all-checked'));
-    userEvent.click(getByTestId('toggle-all-checked'));
+    userEvent.dblClick(getByTestId('toggle-all-checked'));
 
     await waitFor(() => expect(getByTestId('row-checked')).not.toBeChecked());
   });

--- a/src/UserSearchView.test.js
+++ b/src/UserSearchView.test.js
@@ -80,6 +80,8 @@ describe('UserSearchView', () => {
 
     await waitFor(() => expect(getByTestId('row-checked')).toBeChecked());
 
+    // first click checks all entries, second unchecks all entries
+    userEvent.click(getByTestId('toggle-all-checked'));
     userEvent.click(getByTestId('toggle-all-checked'));
 
     await waitFor(() => expect(getByTestId('row-checked')).not.toBeChecked());


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPFU-115

Explanation: as the `useState` updates are async, `reduceUsersToMap` was invoked with stale state for `isAllChecked`. Extracting the old state into a constant within the local scope and performing operations off of the constant (snapshot) state value gets rid of the issue.